### PR TITLE
Task 7: Prometheus Deployment on K8s

### DIFF
--- a/.github/workflows/k3s.yml
+++ b/.github/workflows/k3s.yml
@@ -1,4 +1,4 @@
-name: 'k3s + jenkins'
+name: 'k3s + jenkins + prometheus'
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   terraform:
-    name: 'k3s + jenkins'
+    name: 'k3s + jenkins + prometheus'
     runs-on: ubuntu-latest
 
     steps:
@@ -39,3 +39,5 @@ jobs:
           TF_VAR_k3s_token: ${{ secrets.TF_VAR_K3S_TOKEN }}
           TF_VAR_private_key: ${{ secrets.TF_VAR_PRIVATE_KEY }}
           TF_VAR_private_key_path: ${{ vars.TF_VAR_PRIVATE_KEY_PATH }}
+          TF_VAR_ssl_cert: ${{ secrets.TF_VAR_SSL_CERT }}
+          TF_VAR_ssl_key: ${{ secrets.TF_VAR_SSL_KEY }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@
 ```
 
 <details>
+<summary><strong>Task 7 - Prometheus Deployment on K8s</strong></summary>
+
+- Prometheus is installed and running on the K8s cluster
+- Installed prometheus `node-exporter` and `kube-state-metrics` jobs (exporters). `node-exporter` is dynamically discovered. `kube-state-metrics` is setup as a static scrape target https://github.com/IlyaKozak/rsschool-devops-course-config/blob/task-7-prometheus-deploy/k3s_server_config.tf#L143-L146
+- Deployment is automated with [GitHub Actions CI/CD pipeline is created](https://github.com/IlyaKozak/rsschool-devops-course-config/actions/runs/12102954505/job/33744594616#step:7:411) https://github.com/IlyaKozak/rsschool-devops-course-config/blob/task-7-prometheus-deploy/k3s_server_config.tf#L148-L158
+- Metrics can be checked via Prometheus web interface locally with `port-forwarding`
+- Prometheus is collecting essential cluster-specific metrics, such as nodes' memory usage (memory, disk, cpu, ...)
+
+For more details please see PR: https://github.com/IlyaKozak/rsschool-devops-course-config/pull/2
+
+</details>
+
+<details>
 <summary><strong>Task 4 - Jenkins Installation and Configuration</strong></summary>
 
 - k3s kubernetes cluster is istalled within GitHub Actions workflow
@@ -27,12 +40,12 @@
 
 For more details please see PR: https://github.com/IlyaKozak/rsschool-devops-course-config/pull/1
 
+**Diagram:**  
+![Diagram](tasks-images/task-4-diagram.png)
+
 </details>
 
 <hr />
-
-**Diagram:**  
-![Diagram](tasks-images/task-4-diagram.png)
 
 ### Infractructure
 
@@ -40,4 +53,4 @@ Infrastructure configuration provided in this repo (IaC) **https://github.com/Il
 
 **Usage:**
 
-Add secrets `AWS_ROLE_TO_ASSUME`, `TF_VAR_K3S_TOKEN`, `TF_VAR_PRIVATE_KEY` and environment variable `AWS_REGION`, `TF_VAR_DOMAIN`, `TF_VAR_IS_LOCAL_SETUP`=`false`, `TF_VAR_PRIVATE_KEY_PATH` in GitHub repo for GitHub Actions workflow to run with `workflow_dispatch` ➤ automatically `terraform apply` configuration for k3s and jenkins
+Add secrets `AWS_ROLE_TO_ASSUME`, `TF_VAR_K3S_TOKEN`, `TF_VAR_PRIVATE_KEY`, `TF_VAR_SSL_CERT`, `TF_VAR_SSL_KEY` and environment variable `AWS_REGION`, `TF_VAR_DOMAIN`, `TF_VAR_IS_LOCAL_SETUP`=`false`, `TF_VAR_PRIVATE_KEY_PATH` in GitHub repo for GitHub Actions workflow to run with `workflow_dispatch` ➤ automatically `terraform apply` configuration for k3s and jenkins

--- a/k3s_agent_config.tf
+++ b/k3s_agent_config.tf
@@ -1,31 +1,31 @@
-# data "aws_instance" "k3s_agent" {
-#   filter {
-#     name   = "tag:Name"
-#     values = ["k3s_agent"]
-#   }
+data "aws_instance" "k3s_agent" {
+  filter {
+    name   = "tag:Name"
+    values = ["k3s_agent"]
+  }
 
-#   filter {
-#     name   = "instance-state-name"
-#     values = ["running"]
-#   }
-# }
+  filter {
+    name   = "instance-state-name"
+    values = ["running"]
+  }
+}
 
-# resource "null_resource" "k3s_agent" {
-#   depends_on = [null_resource.k3s_server]
+resource "null_resource" "k3s_agent" {
+  depends_on = [null_resource.k3s_server]
 
-#   provisioner "remote-exec" {
-#     connection {
-#       type         = "ssh"
-#       user         = "ec2-user"
-#       host         = data.aws_instance.k3s_agent.private_ip
-#       bastion_host = data.aws_eip.nat_instance.public_ip
-#       private_key  = var.private_key
-#       timeout      = "1m"
-#     }
+  provisioner "remote-exec" {
+    connection {
+      type         = "ssh"
+      user         = "ec2-user"
+      host         = data.aws_instance.k3s_agent.private_ip
+      bastion_host = data.aws_eip.nat_instance.public_ip
+      private_key  = var.private_key
+      timeout      = "1m"
+    }
 
-#     inline = [
-#       # install k3s and connect to k3s cluster
-#       "curl -sfL https://get.k3s.io | sudo K3S_URL=https://${data.aws_instance.k3s_server.private_ip}:6443 K3S_TOKEN=${var.k3s_token} sh -s -",
-#     ]
-#   }
-# }
+    inline = [
+      # install k3s and connect to k3s cluster
+      "curl -sfL https://get.k3s.io | sudo K3S_URL=https://${data.aws_instance.k3s_server.private_ip}:6443 K3S_TOKEN=${var.k3s_token} sh -s -",
+    ]
+  }
+}

--- a/k3s_agent_config.tf
+++ b/k3s_agent_config.tf
@@ -1,31 +1,31 @@
-data "aws_instance" "k3s_agent" {
-  filter {
-    name   = "tag:Name"
-    values = ["k3s_agent"]
-  }
+# data "aws_instance" "k3s_agent" {
+#   filter {
+#     name   = "tag:Name"
+#     values = ["k3s_agent"]
+#   }
 
-  filter {
-    name   = "instance-state-name"
-    values = ["running"]
-  }
-}
+#   filter {
+#     name   = "instance-state-name"
+#     values = ["running"]
+#   }
+# }
 
-resource "null_resource" "k3s_agent" {
-  depends_on = [null_resource.k3s_server]
+# resource "null_resource" "k3s_agent" {
+#   depends_on = [null_resource.k3s_server]
 
-  provisioner "remote-exec" {
-    connection {
-      type         = "ssh"
-      user         = "ec2-user"
-      host         = data.aws_instance.k3s_agent.private_ip
-      bastion_host = data.aws_eip.nat_instance.public_ip
-      private_key  = var.private_key
-      timeout      = "1m"
-    }
+#   provisioner "remote-exec" {
+#     connection {
+#       type         = "ssh"
+#       user         = "ec2-user"
+#       host         = data.aws_instance.k3s_agent.private_ip
+#       bastion_host = data.aws_eip.nat_instance.public_ip
+#       private_key  = var.private_key
+#       timeout      = "1m"
+#     }
 
-    inline = [
-      # install k3s and connect to k3s cluster
-      "curl -sfL https://get.k3s.io | sudo K3S_URL=https://${data.aws_instance.k3s_server.private_ip}:6443 K3S_TOKEN=${var.k3s_token} sh -s -",
-    ]
-  }
-}
+#     inline = [
+#       # install k3s and connect to k3s cluster
+#       "curl -sfL https://get.k3s.io | sudo K3S_URL=https://${data.aws_instance.k3s_server.private_ip}:6443 K3S_TOKEN=${var.k3s_token} sh -s -",
+#     ]
+#   }
+# }

--- a/k3s_server_config.tf
+++ b/k3s_server_config.tf
@@ -5,13 +5,6 @@ data "aws_ebs_volume" "jenkins_volume" {
   }
 }
 
-data "aws_ebs_volume" "sonarqube_volume" {
-  filter {
-    name   = "tag:Name"
-    values = ["sonarqube"]
-  }
-}
-
 resource "null_resource" "k3s_server" {
   depends_on = [null_resource.nat_instance]
 
@@ -76,8 +69,9 @@ resource "null_resource" "k3s_server" {
       "sleep 10",
       "done",
 
+      "export KUBECONFIG=/etc/rancher/k3s/k3s.yaml",
       # install aws-ebs-csi-driver
-      "sudo KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm install aws-ebs-csi-driver --namespace kube-system aws-ebs-csi-driver/aws-ebs-csi-driver",
+      "sudo -E helm install aws-ebs-csi-driver --namespace kube-system aws-ebs-csi-driver/aws-ebs-csi-driver",
 
       # create jenkins persistent volume
       "cat <<EOF | sudo kubectl apply -f -",
@@ -103,35 +97,8 @@ resource "null_resource" "k3s_server" {
       "                - ${var.aws_az}",
       "EOF",
 
-      # create sonarqube persistent volume
-      "cat <<EOF | sudo kubectl apply -f -",
-      "apiVersion: v1",
-      "kind: PersistentVolume",
-      "metadata:",
-      "  name: ${var.sonarqube.pv}",
-      "spec:",
-      "  accessModes:",
-      "  - ReadWriteOnce",
-      "  capacity:",
-      "    storage: ${var.sonarqube.volume_size}",
-      "  csi:",
-      "    driver: ebs.csi.aws.com",
-      "    volumeHandle: ${data.aws_ebs_volume.sonarqube_volume.id}",
-      "  nodeAffinity:",
-      "    required:",
-      "      nodeSelectorTerms:",
-      "        - matchExpressions:",
-      "            - key: topology.kubernetes.io/zone",
-      "              operator: In",
-      "              values:",
-      "                - ${var.aws_az}",
-      "EOF",
-
       # create jenkins namespace
       "sudo kubectl create namespace ${var.jenkins.namespace}",
-
-      # create sonarqube namespace
-      "sudo kubectl create namespace ${var.sonarqube.namespace}",
 
       # create jenkins persistent volume claim
       "cat <<EOF | sudo kubectl apply -f -",
@@ -150,23 +117,6 @@ resource "null_resource" "k3s_server" {
       "      storage: ${var.jenkins.volume_size}",
       "EOF",
 
-      # create sonarqube persistent volume claim
-      "cat <<EOF | sudo kubectl apply -f -",
-      "apiVersion: v1",
-      "kind: PersistentVolumeClaim",
-      "metadata:",
-      "  name: ${var.sonarqube.pvc}",
-      "  namespace: ${var.sonarqube.namespace}",
-      "spec:",
-      "  storageClassName: ''",
-      "  volumeName: ${var.sonarqube.pv}",
-      "  accessModes:",
-      "    - ReadWriteOnce",
-      "  resources:",
-      "    requests:",
-      "      storage: ${var.sonarqube.volume_size}",
-      "EOF",
-
       # create ebs storage class for dynamic persistent volumes provisioning
       "cat <<EOF | sudo kubectl apply -f -",
       "apiVersion: storage.k8s.io/v1",
@@ -183,22 +133,18 @@ resource "null_resource" "k3s_server" {
       "--user=kubelet --group=system:serviceaccounts",
 
       # install jenkins to k8s with pv statically provisioned ebs volume and expose it via traefik ingress
-      "sudo KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm upgrade --install -n jenkins jenkins jenkins/jenkins \\",
+      "sudo -E helm upgrade --install -n jenkins jenkins jenkins/jenkins \\",
       "--set controller.ingress.enabled=true \\",
       "--set controller.ingress.hostName=jenkins.${var.domain} \\",
       "--set controller.ingress.annotations.\"traefik\\.ingress\\.kubernetes\\.io/router\\.entrypoints\"=web \\",
       "--set persistence.existingClaim=${var.jenkins.pvc} \\",
       "--set rbac.readSecrets=true",
 
-      # install sonarqube to k8s with pv statically provisioned ebs volume and expose it via traefik ingress
-      "sudo KUBECONFIG=/etc/rancher/k3s/k3s.yaml helm upgrade --install -n sonarqube sonarqube sonarqube/sonarqube \\",
-      "--set ingress.enabled=true \\",
-      "--set ingress.hosts[0].name=sonarqube.${var.domain} \\",
-      "--set ingress.annotations.\"traefik\\.ingress\\.kubernetes\\.io/router\\.entrypoints\"=web \\",
-      "--set postgresql.persistence.size=${var.sonarqube.volume_size} \\",
-      "--set postgresql.image.tag=13.17.0-debian-12-r0 \\",
-      "--set persistence.enabled=true \\",
-      "--set persistence.existingClaim=${var.sonarqube.pvc}",
+      # install prometheus to k8s and expose it via traefik ingress
+      "sudo -E helm upgrade --install -n prometheus --create-namespace prometheus oci://registry-1.docker.io/bitnamicharts/prometheus \\",
+      "--set server.ingress.enabled=true \\",
+      "--set server.ingress.hostname=prometheus.${var.domain} \\",
+      "--set server.ingress.annotations.\"traefik\\.ingress\\.kubernetes\\.io/router\\.entrypoints\"=web \\",
     ]
   }
 }


### PR DESCRIPTION
1. Task requirements: [Task 7 - Prometheus Deployment on K8s](https://github.com/rolling-scopes-school/tasks/blob/master/devops/modules/4_monitoring-configuration/task_7.md)

2. Submitted: 01.12.2024 / Deadline: 02.12.2024

3. Cross-check self-evaluation **100/100**

[Task 7 README](https://github.com/IlyaKozak/rsschool-devops-course-config/blob/task-7-prometheus-deploy/README.md)

For infrastructure setup see the repo https://github.com/IlyaKozak/rsschool-devops-course-infra
For infrastructure CI/CD deploy see GitHub Actions workflow https://github.com/IlyaKozak/rsschool-devops-course-infra/actions/runs/12102873826/job/33744409251

**Prometheus Installation (20 points)**
- [x] Prometheus is installed and running on the K8s cluster
<p><image src="https://github.com/user-attachments/assets/81d9c2c4-bba2-451e-9ab6-33764127b545" width=800 /></p>
<p><image src="https://github.com/user-attachments/assets/d97f8d40-26b0-4a53-ad85-8715d0b454b2" width=600 /></p>
<p><image src="https://github.com/user-attachments/assets/8d0ba342-2a00-46e6-bc57-6e3100d1cd8f" /></p>  

- [x] Installed prometheus `node-exporter` and `kube-state-metrics` jobs (exporters). `node-exporter` is dynamically discovered. `kube-state-metrics` is setup as a static scrape target
https://github.com/IlyaKozak/rsschool-devops-course-config/blob/task-7-prometheus-deploy/k3s_server_config.tf#L143-L146
<p><image src="https://github.com/user-attachments/assets/d1c9a43e-c307-41d7-a682-05f131c08190" /></p>  

**Deployment Automation (30 points)**
- [x] Automation of deployment with [GitHub Actions CI/CD pipeline is created](https://github.com/IlyaKozak/rsschool-devops-course-config/actions/runs/12102954505/job/33744594616#step:7:411)
https://github.com/IlyaKozak/rsschool-devops-course-config/blob/task-7-prometheus-deploy/k3s_server_config.tf#L148-L158
<p><image src="https://github.com/user-attachments/assets/78a6b01a-c1ec-4e84-a734-496c200afef6" width=600 /></p>

**Web interface is available (10 points)**
- [x] Metrics can be checked via Prometheus web interface locally with `port-forwarding`:
<p><image src="https://github.com/user-attachments/assets/a164caa1-485a-4ed7-892c-dd46a226254a" width=500 /></p>
<p><image src="https://github.com/user-attachments/assets/e4f30e4d-5982-40b9-bbfb-b32a97e71dd2" /></p>

**Metrics Collection (35 points)**
- [x] Prometheus is collecting essential cluster-specific metrics, such as nodes' memory usage:  
   - <p>Memory Available in bytes:<image src="https://github.com/user-attachments/assets/71b1c074-946e-42f0-a216-29bafae22ebc" /></p> 
   - <p>Memory Available %:<image src="https://github.com/user-attachments/assets/9783b1c2-4f30-4754-8a91-8ccdcc3ae757" /></p> 
   - <p>Disk Space Usage %:<image src="https://github.com/user-attachments/assets/48c6825e-dab8-4240-a9b2-32ff9cefb905" /></p> 
   - <p>CPU (percentage of non-idle CPU usage over the last 5 minutes):<image src="https://github.com/user-attachments/assets/4064faa5-52b6-402c-b45c-4be27f562dde" /></p> 

**Documentation is created (5 points)**
- [x] [README file](https://github.com/IlyaKozak/rsschool-devops-course-config/blob/task-7-prometheus-deploy/README.md) is updated documenting the Prometheus deployment and configuration.
